### PR TITLE
removed graphql import to fix version conflicts

### DIFF
--- a/src/PostGraphileManyDeletePlugin.ts
+++ b/src/PostGraphileManyDeletePlugin.ts
@@ -1,6 +1,5 @@
 import * as T from './pluginTypes';
 import debugFactory from 'debug';
-import { GraphQLList } from 'graphql';
 const debug = debugFactory('graphile-build-pg');
 
 const PostGraphileManyDeletePlugin: T.Plugin = (
@@ -44,6 +43,7 @@ const PostGraphileManyDeletePlugin: T.Plugin = (
       pgIntrospectionResultsByKind,
       pgSql: sql,
       graphql: {
+        GraphQLList,
         GraphQLNonNull,
         GraphQLInputObjectType,
         GraphQLString,

--- a/src/PostGraphileManyUpdatePlugin.ts
+++ b/src/PostGraphileManyUpdatePlugin.ts
@@ -1,6 +1,5 @@
 import * as T from './pluginTypes';
 import debugFactory from 'debug';
-import { GraphQLList } from 'graphql';
 const debug = debugFactory('graphile-build-pg');
 
 const PostGraphileManyUpdatePlugin: T.Plugin = (
@@ -44,6 +43,7 @@ const PostGraphileManyUpdatePlugin: T.Plugin = (
       pgIntrospectionResultsByKind,
       pgSql: sql,
       graphql: {
+        GraphQLList,
         GraphQLNonNull,
         GraphQLInputObjectType,
         GraphQLString,


### PR DESCRIPTION
When using this plugin on the current version of postgraphile mutations are no longer included and I get the following error:

```
Recoverable error occurred:
2022-05-03T21:37:58.792Z graphile-build:warn Error: Cannot use GraphQLNonNull "CallCarrierLinePatch!" from another module or realm.

Ensure that there is only one instance of "graphql" in the node_modules
directory. If different versions of "graphql" are the dependencies of other
relied on modules, use "resolutions" to ensure only one version is installed.

https://yarnpkg.com/en/docs/selective-version-resolutions

Duplicate "graphql" modules cannot be used at the same time since different
versions may have different capabilities and behavior. The data from one
version used in the function from another could produce confusing and
spurious results.
    at instanceOf (/usr/local/lib/node_modules/postgraphile-plugin-many-create-update-delete/node_modules/graphql/jsutils/instanceOf.js:35:13)
    at isNonNullType (/usr/local/lib/node_modules/postgraphile-plugin-many-create-update-delete/node_modules/graphql/type/definition.js:200:34)
    at isType (/usr/local/lib/node_modules/postgraphile-plugin-many-create-update-delete/node_modules/graphql/type/definition.js:92:167)
    at assertType (/usr/local/lib/node_modules/postgraphile-plugin-many-create-update-delete/node_modules/graphql/type/definition.js:96:8)
    at new GraphQLList (/usr/local/lib/node_modules/postgraphile-plugin-many-create-update-delete/node_modules/graphql/type/definition.js:323:19)
    at /usr/local/lib/node_modules/postgraphile-plugin-many-create-update-delete/build/PostGraphileManyUpdatePlugin.js:116:35
    at Array.forEach (<anonymous>)
    at handleAdditionsFromTableInfo (/usr/local/lib/node_modules/postgraphile-plugin-many-create-update-delete/build/PostGraphileManyUpdatePlugin.js:89:31)
    at GQLObjectFieldsHookHandlerFcn (/usr/local/lib/node_modules/postgraphile-plugin-many-create-update-delete/build/PostGraphileManyUpdatePlugin.js:32:13)
    at SchemaBuilder.applyHooks (/usr/local/lib/node_modules/postgraphile/node_modules/graphile-build/node8plus/SchemaBuilder.js:264:20)
```

This is due to the graphql import in 2 packages.  This uses the included `graphql` object provided from postgraphile so the import is not needed.  This solves the error and mutations are included, along with the `mn` prefixed mutations.